### PR TITLE
Allow collections aswell

### DIFF
--- a/src/Form/DataTransformer/ObjectToIdTransformer.php
+++ b/src/Form/DataTransformer/ObjectToIdTransformer.php
@@ -54,7 +54,7 @@ class ObjectToIdTransformer implements DataTransformerInterface
 
         $accessor = PropertyAccess::createPropertyAccessor();
 
-        if ($this->multiple && \is_array($entity)) {
+        if ($this->multiple && (is_array($entity) || $entity instanceof \Traversable)) {
             $value = [];
 
             foreach ($entity as $e) {


### PR DESCRIPTION
Hi!

my colleague currently use your bundle and stumbled upon a issue in your bundle.
The ObjectIdToTransformer actually supports only arrays.

With my PR it supports all traversable objects, like doctrine collections.